### PR TITLE
Fix error naming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage:
 
 ```terminal
 $ flake8 test.py
-test.py:1:1: CCE001 is too complex (4 > 1)
+test.py:1:1: CAC001 is too complex (4 > 1)
 ```
 
 Tested on Python 3.7.2 and flake8 3.5.0.

--- a/flake8_adjustable_complexity/checker.py
+++ b/flake8_adjustable_complexity/checker.py
@@ -8,7 +8,7 @@ class CyclomaticComplexityAjustableChecker:
     name = 'flake8-adjustable-complexity'
     version = version
 
-    _error_message_template = 'CCE001 is too complex ({0} > {1})'
+    _error_message_template = 'CAC001 is too complex ({0} > {1})'
 
     BAD_VAR_NAME_PENALTY = 2
     ALLOW_SINGLE_NAMES_IN_VARS = False

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=['setuptools'],
     entry_points={
         'flake8.extension': [
-            'CCE001 = flake8_adjustable_complexity.checker:CyclomaticComplexityAjustableChecker',
+            'CAC001 = flake8_adjustable_complexity.checker:CyclomaticComplexityAjustableChecker',
         ],
     },
     url='https://github.com/best-doctor/flake8-adjustable-complexity',


### PR DESCRIPTION
Код ошибки `CCE001` используется в 2-х плагинах:
* flake8-adjustable-complexity
* flake8-class-attributes-order

Предлагаю изменить код ошибки в плагине **flake8-adjustable-complexity** на `CAC001`.