### PR TITLE
ENG-772: Add per-path configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 
 
 .idea/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ blacklist inside the function. If actual complexity overcomes max calculated
 complexity, the plugin reports an error.
 
 Max allowed cyclomatic complexity can be configured via
-`--max-mccabe-complexity` option.
+`--max-mccabe-complexity` (or `--max-adjustable-complexity`) option. The plugin
+also accepts `--per-path-max-adjustable-complexity` to define a simple per-path
+complexity settings. The value of the option must be a comma-delimited list
+of `<path>:<complexity>` pairs.
+
+Both options also can be specified via `[flake8]` section of `setup.cfg`.
 
 ## Installation
 

--- a/flake8_adjustable_complexity/ast_helpers.py
+++ b/flake8_adjustable_complexity/ast_helpers.py
@@ -3,8 +3,10 @@ from typing import List, Union
 
 from flake8_adjustable_complexity.list_helpers import flat
 
+FuncDef = Union[ast.FunctionDef, ast.AsyncFunctionDef]
 
-def get_all_funcdefs_from(tree: ast.AST):
+
+def get_all_funcdefs_from(tree: ast.AST) -> List[FuncDef]:
     return [
         n for n in ast.walk(tree)
         if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))

--- a/flake8_adjustable_complexity/checker.py
+++ b/flake8_adjustable_complexity/checker.py
@@ -1,4 +1,11 @@
-from typing import Generator, Tuple
+from __future__ import annotations
+
+import argparse
+import ast
+from typing import Dict, Generator, Tuple
+
+from flake8.exceptions import ExecutionError
+from flake8.options.manager import OptionManager
 
 from flake8_adjustable_complexity import __version__ as version
 from flake8_adjustable_complexity.complexity_helpers import validate_adjustable_complexity_in_tree
@@ -45,33 +52,64 @@ class CyclomaticComplexityAjustableChecker:
     name = 'flake8-adjustable-complexity'
     version = version
 
-    _error_message_template = 'CAC001 is too complex ({0} > {1})'
+    _error_message_template = 'CAC001 {0} is too complex ({1} > {2})'
 
     max_mccabe_complexity = 0
+    max_complexity_per_path: Dict[str, int] = {}
 
-    def __init__(self, tree, filename: str):
+    def __init__(self, tree: ast.AST, filename: str):
         self.filename = filename
         self.tree = tree
 
     @classmethod
-    def add_options(cls, parser) -> None:
+    def add_options(cls, parser: OptionManager) -> None:
+        for option in ('--max-mccabe-complexity', '--max-adjustable-complexity'):
+            parser.add_option(
+                option,
+                type=int,
+                dest='max_mccabe_complexity',
+                parse_from_config=True,
+                help='Max mccabe complexity',
+                default=cls.DEFAULT_MAX_MCCABE_COMPLEXITY,
+            )
+
         parser.add_option(
-            '--max-mccabe-complexity',
-            type=int,
+            '--per-path-max-adjustable-complexity',
+            dest='max_complexity_per_path',
+            comma_separated_list=True,
             parse_from_config=True,
-            help='Max mccabe complexity',
-            default=cls.DEFAULT_MAX_MCCABE_COMPLEXITY,
+            help=(
+                'Comma-separated list of pairs of files or directories to '
+                'check and the desired max complexity value within that path.'
+            ),
+            default='',
         )
 
     @classmethod
-    def parse_options(cls, options) -> None:
+    def parse_options(cls, options: argparse.Namespace) -> None:
         cls.max_mccabe_complexity = int(options.max_mccabe_complexity)
+        for item in options.max_complexity_per_path:
+            path, max_complexity = item.split(':', maxsplit=1)
+            try:
+                cls.max_complexity_per_path[path] = int(max_complexity)
+            except ValueError:
+                raise ExecutionError(
+                    "Couldn\'t parse --per-path-adjustable-max-complexity value into "
+                    f'dictionary, expected number, got string "{max_complexity}"',
+                )
 
     def run(self) -> Generator[Tuple[int, int, str, type], None, None]:
+        max_complexity = self.max_mccabe_complexity
+        if self.max_complexity_per_path:
+            for path, complexity in self.max_complexity_per_path.items():
+                if path in self.filename:
+                    max_complexity = complexity
+                    break
+
         too_difficult_functions = validate_adjustable_complexity_in_tree(
             self.tree,
             var_names_blacklist=self.VAR_NAMES_BLACKLIST,
-            max_complexity=self.max_mccabe_complexity,
+            max_complexity=max_complexity,
             bad_var_name_penalty=self.BAD_VAR_NAME_PENALTY,
             allow_single_names_in_vars=self.ALLOW_SINGLE_NAMES_IN_VARS,
             single_letter_var_whitelist=self.SINGLE_LETTER_VAR_WHITELIST,
@@ -81,6 +119,6 @@ class CyclomaticComplexityAjustableChecker:
             yield (
                 funcdef.lineno,
                 funcdef.col_offset,
-                self._error_message_template.format(actual_complexity, max_expected_complexity),
+                self._error_message_template.format(funcdef.name, actual_complexity, max_expected_complexity),
                 type(self),
             )

--- a/flake8_adjustable_complexity/complexity_helpers.py
+++ b/flake8_adjustable_complexity/complexity_helpers.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Tuple, Set
 import mccabe
 
 from flake8_adjustable_complexity.ast_helpers import (
-    get_all_funcdefs_from,
+    FuncDef, get_all_funcdefs_from,
     extract_all_vars_in_node,
 )
 
@@ -16,7 +16,7 @@ def validate_adjustable_complexity_in_tree(
     bad_var_name_penalty: int,
     allow_single_names_in_vars: bool,
     single_letter_var_whitelist: Optional[List[str]] = None,
-) -> List[Tuple[ast.AST, int, int]]:
+) -> List[Tuple[FuncDef, int, int]]:
     errors = []
     for funcdef in get_all_funcdefs_from(tree):
         error_in_funcdef = check_funcdef_adjustable_complexity(
@@ -33,13 +33,13 @@ def validate_adjustable_complexity_in_tree(
 
 
 def check_funcdef_adjustable_complexity(
-    funcdef: ast.FunctionDef,
+    funcdef: FuncDef,
     var_names_blacklist: Set[str],
     default_max_complexity: int,
     bad_var_name_penalty: int,
     allow_single_names_in_vars: bool,
     single_letter_var_whitelist: Optional[List[str]] = None,
-) -> Optional[Tuple[ast.AST, int, int]]:
+) -> Optional[Tuple[FuncDef, int, int]]:
     single_letter_var_whitelist = single_letter_var_whitelist or []
     funcdef_vars = extract_all_vars_in_node(funcdef)
     vars_from_blacklist_amount = sum(1 for v in funcdef_vars if v in var_names_blacklist)
@@ -51,8 +51,7 @@ def check_funcdef_adjustable_complexity(
         )
     max_allowed_cyclomatic_complexity = (
         default_max_complexity
-        - bad_var_name_penalty
-        * vars_from_blacklist_amount
+        - bad_var_name_penalty * vars_from_blacklist_amount
         - additional_penalty
     )
     current_mccabe_complexity = get_mccabe_complexity_for(funcdef)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 import ast
 import os
 
+from flake8.options.manager import OptionManager
+
 from flake8_adjustable_complexity.checker import CyclomaticComplexityAjustableChecker
 
 
-def run_validator_for_test_file(filename):
+def run_validator_for_test_file(filename, args=None):
     test_file_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         'test_files',
@@ -13,6 +15,13 @@ def run_validator_for_test_file(filename):
     with open(test_file_path, 'r') as file_handler:
         raw_content = file_handler.read()
     tree = ast.parse(raw_content)
+
+    if args:
+        manager = OptionManager(version='1.0')
+        CyclomaticComplexityAjustableChecker.add_options(manager)
+        options, _ = manager.parse_args(args)
+        CyclomaticComplexityAjustableChecker.parse_options(options)
+
     checker = CyclomaticComplexityAjustableChecker(tree=tree, filename=filename)
 
     return list(checker.run())

--- a/tests/test_adjustable_complexity.py
+++ b/tests/test_adjustable_complexity.py
@@ -9,3 +9,25 @@ def test_get_error_for_too_complex_file():
 def test_get_error_for_not_too_complex_file_with_blacklisted_vars():
     errors = run_validator_for_test_file('too_complex_with_blacklisted.py')
     assert len(errors) == 1
+
+
+def test_get_no_error_for_per_path_excluded_file():
+    errors = run_validator_for_test_file(
+        'too_complex_with_blacklisted.py',
+        args=[
+            '--per-path-max-adjustable-complexity',
+            'too_complex_with_blacklisted.py:99',
+        ],
+    )
+    assert len(errors) == 0
+
+
+def test_get_error_for_per_path_not_excluded_file():
+    errors = run_validator_for_test_file(
+        'too_complex.py',
+        args=[
+            '--per-path-max-adjustable-complexity',
+            'too_complex_with_blacklisted.py:99',
+        ],
+    )
+    assert len(errors) == 1


### PR DESCRIPTION
This is needed to align functionality with existing validator in 'core' to be able to get rid of it and use the plugin instead